### PR TITLE
feat: peregrine toolchain spike — .ast→Rust gate result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,15 @@ ir_program_filtered.json
 trace.bin
 *.pb
 
+# Peregrine toolchain (local-only, not tracked in git)
+tools/peregrine-tool/
+tools/lean-to-lambdabox/
+
+# Spike build artifacts
+spike/**/extraction/
+spike/**/rust-check/target/
+spike/**/.lake/
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/docs/generated/TOOLCHAIN.md
+++ b/docs/generated/TOOLCHAIN.md
@@ -1,0 +1,73 @@
+---
+title: Peregrine Toolchain Versions
+last_updated: 2026-03-17
+tags:
+  - peregrine
+  - toolchain
+---
+
+# Peregrine Toolchain Versions
+
+## peregrine-tool
+
+- **Repository**: <https://github.com/peregrine-project/peregrine-tool>
+- **SHA**: `840930f399d722dd890fc836a8e9a025db0b035a`
+- **Branch**: master (Merge pull request #58 from peregrine-project/metarocq-1.5.1)
+
+### Build instructions
+
+```bash
+cd tools/peregrine-tool
+
+# Requires opam switch at /home/shouki/peregrine-tool with deps installed.
+# Key packages: rocq-core 9.1.1, rocq-metarocq-* 1.5.1+9.1, malfunction 0.7
+# rocq-verified-extraction and rocq-certirocq built from source (see notes below).
+
+# Build Coq theories (skip WasmBackend — patched out):
+opam exec --switch /home/shouki/peregrine-tool -- make -k
+
+# Build OCaml binary:
+opam exec --switch /home/shouki/peregrine-tool -- dune build
+
+# Run:
+opam exec --switch /home/shouki/peregrine-tool -- dune exec peregrine -- <LANG> <FILE> -o <OUT>
+```
+
+### Build notes
+
+- `rocq-verified-extraction` v1.0.0+9.1 requires `malfunction >= 0.7.1` but only `0.7` is available. Built from source at `/tmp/rocq-verified-extraction` and `.vo` files installed manually.
+- `rocq-certirocq` requires `coq-wasm` which has dune build conflicts. Built from source with `CodegenWasm` commented out. `Compiler/pipeline.v` patched to remove Wasm imports.
+- `WasmBackend.v` in peregrine-tool cannot compile without `coq-wasm`. Patched `ConfigUtils.v` and `Pipeline.v` to stub out Wasm references.
+
+### Key opam packages (opam switch: `/home/shouki/peregrine-tool`)
+
+| Package | Version |
+|---------|---------|
+| ocaml-base-compiler | 4.14.2 |
+| rocq-core | 9.1.1 |
+| rocq-metarocq-common | 1.5.1+9.1 |
+| rocq-metarocq-erasure | 1.5.1+9.1 |
+| rocq-metarocq-erasure-plugin | 1.5.1+9.1 |
+| rocq-rust-extraction | 0.2.1 |
+| rocq-typed-extraction-common | 0.2.1 |
+| malfunction | 0.7 (pinned from git) |
+| coq-compcert | 3.17 |
+| rocq-equations | 1.3.1+9.1 |
+
+## lean-to-lambdabox
+
+- **Repository**: <https://github.com/peregrine-project/lean-to-lambdabox>
+- **SHA**: `f54d17d04402459effb35851cbba3bbe8e4ffbef`
+- **lean-toolchain**: `leanprover/lean4:v4.22.0`
+
+### Build instructions
+
+```bash
+cd tools/lean-to-lambdabox
+lake build
+```
+
+## Dependency versions (for generated code)
+
+No Rust code was generated (see FINDINGS.md for details).
+The C backend generates code depending on CertiRocq's GC runtime (`gc_stack.h`).

--- a/justfile
+++ b/justfile
@@ -50,6 +50,26 @@ bench-ir-trace-cycles VALIDATORS="10":
         echo
     done
 
+# Local-only: requires opam + peregrine toolchain
+setup-peregrine:
+    cd tools/peregrine-tool && opam switch create . 4.14.2 \
+      --repositories default,coq-released=https://coq.inria.fr/opam/released \
+    && opam install . --deps-only
+
+# Local-only: requires opam + peregrine toolchain
+build-peregrine:
+    cd tools/peregrine-tool && opam exec --switch . -- make
+
+# Local-only: requires lean + lean-to-lambdabox
+setup-lean-to-lambdabox:
+    cd tools/lean-to-lambdabox && lake build
+
+# Local-only: run trivial extraction spike
+spike-trivial:
+    cd spike/trivial && lake build
+    cd tools/peregrine-tool && opam exec --switch . -- dune exec peregrine -- rust \
+      ../../spike/trivial/extraction/identity.ast -o ../../spike/trivial/extraction/identity.rs
+
 # Clean all artifacts
 clean:
     cargo clean

--- a/spike/FINDINGS.md
+++ b/spike/FINDINGS.md
@@ -1,0 +1,95 @@
+---
+title: Peregrine Spike Findings
+last_updated: 2026-03-17
+tags:
+  - peregrine
+  - spike
+---
+
+# Peregrine Spike Findings (Issue #4)
+
+## Summary
+
+**Go/No-Go for Issue #5: NO-GO via Rust backend. C backend is a viable alternative path.**
+
+The `.ast → Rust` gate **failed**: peregrine's Rust backend requires **typed** lambda box
+input (`.tast` format), but lean-to-lambdabox only produces **untyped** output (`.ast` format).
+The C and OCaml backends accept untyped input and work correctly.
+
+## .ast vs .tast Gate Result
+
+| Backend | Input type required | lean-to-lambdabox output | Result |
+|---------|-------------------|-------------------------|--------|
+| **Rust** | Typed (`.tast`) | Untyped (`.ast`) | **FAIL** |
+| **Elm** | Typed (`.tast`) | Untyped (`.ast`) | **FAIL** |
+| **C** | Untyped (`.ast`) | Untyped (`.ast`) | **PASS** |
+| **OCaml** | Untyped (`.ast`) | Untyped (`.ast`) | **PASS** |
+| **CakeML** | Untyped (`.ast`) | Untyped (`.ast`) | Expected PASS |
+| **Wasm** | Untyped (`.ast`) | Untyped (`.ast`) | Not tested (deps unavailable) |
+
+### Root cause
+
+In `lean-to-lambdabox/LeanToLambdaBox/Erasure.lean` line 361:
+```lean
+return (.untyped s.gdecls (.some t), s.inlinings)
+```
+The erasure always produces `Program.untyped`. There is no `.typed` variant implemented.
+
+In `peregrine-tool/theories/Pipeline.v` line 74:
+```coq
+| Rust _ => assert (is_typed_ast p) "Rust extraction requires typed lambda box input"
+```
+
+### Error message
+```
+Could not compile:
+Rust extraction requires typed lambda box input
+```
+
+## Generated Rust Dependencies / Module Structure
+
+**N/A** — no Rust code was generated due to the typed IR requirement.
+
+## ByteArray Support (ABI Spike)
+
+- Built-in `ByteArray` was **not tested** with `#erase` (expected to fail as it's an opaque type)
+- Custom byte types (`Bit`, `Byte`, `ByteList`) work with `#erase`:
+  - `byteIdentity.ast` — generated successfully
+  - `byteLength.ast` — generated successfully (includes Nat operations)
+  - `byteConcat.ast` — generated successfully
+- All custom byte type `.ast` files compile to C via peregrine
+
+## RISC-0 Guest Compile + Execution
+
+**Not tested** — blocked by Rust backend gate failure. No generated Rust code to compile.
+
+## Peregrine Toolchain Build Issues
+
+1. `rocq-verified-extraction >= 1.0.0+9.1` requires `malfunction >= 0.7.1`, but opam only has `0.7`. Fixed by building from source.
+2. `rocq-certirocq` requires `coq-wasm`, which has dune build conflicts when built inside the peregrine-tool directory. Fixed by building from source with Wasm backend removed.
+3. Peregrine's `WasmBackend.v` cannot compile without `coq-wasm`. Patched `ConfigUtils.v` and `Pipeline.v` to stub out Wasm references.
+
+## Recommendations for Issue #5
+
+### Option A: Add typed IR support to lean-to-lambdabox
+- Modify `Erasure.lean` to produce `Program.typed` output
+- This requires implementing type preservation through the erasure process
+- **Effort**: High — the typed format requires ExAst (extended AST with types), which is significantly more complex than the untyped format
+- **Risk**: lean-to-lambdabox's architecture is fundamentally based on type erasure
+
+### Option B: Use C backend instead of Rust
+- The C backend works with untyped `.ast` and generates C code
+- The generated C code depends on CertiRocq's GC runtime (`gc_stack.h`)
+- Would need to compile C code for riscv32im target and link into RISC-0 guest
+- **Effort**: Medium — need cross-compilation setup and GC runtime porting
+- **Risk**: GC runtime may not work in `no_std` / zkVM environment
+
+### Option C: Upstream enhancement request
+- File an issue on lean-to-lambdabox requesting typed IR output
+- File an issue on peregrine-tool requesting untyped Rust backend support
+- **Effort**: Low (for us), but timeline uncertain
+
+### Option D: Direct Lean4 → RISC-0 compilation
+- Skip peregrine entirely and compile Lean4 natively to riscv32im
+- Lean4 has C backend support built-in
+- **Effort**: Medium — need Lean4 cross-compilation to riscv32im

--- a/spike/FINDINGS_ja.md
+++ b/spike/FINDINGS_ja.md
@@ -1,0 +1,40 @@
+---
+title: Peregrine スパイク調査結果
+last_updated: 2026-03-17
+tags:
+  - peregrine
+  - spike
+---
+
+# Issue #4 スパイク結果まとめ
+
+## 目的
+
+Lean4 → LambdaBox → Rust → RISC-0 のパイプラインが動くか検証する。
+
+## 結論：Rust パスは現時点で不可
+
+| 項目 | 結果 |
+|------|------|
+| lean-to-lambdabox で `.ast` 生成 | ✅ 成功 |
+| peregrine で `.ast` → Rust 変換 | ❌ **失敗** |
+| peregrine で `.ast` → C 変換 | ✅ 成功 |
+| RISC-0 ゲストでの実行 | ⏭ 未到達 |
+
+## 失敗の原因
+
+- peregrine の **Rust バックエンド**は **typed IR（.tast）** を要求する
+- lean-to-lambdabox は **untyped IR（.ast）** しか出力できない
+- この 2 つのギャップを埋める手段が現時点では存在しない
+
+## 動いたもの
+
+- C / OCaml バックエンドは untyped `.ast` を受け付け、正常にコード生成できた
+- カスタムバイト型（`Bit`, `Byte`, `ByteList`）は `#erase` で問題なく `.ast` に変換できた
+
+## 次のステップの選択肢
+
+1. **lean-to-lambdabox に typed IR 出力を追加する**（高難度・upstream 改修）
+2. **C バックエンドで生成した C コードを riscv32im にクロスコンパイルする**（GC ランタイムの移植が必要）
+3. **upstream に enhancement request を出す**（タイムライン不明）
+4. **Lean4 のネイティブ C バックエンドで直接 riscv32im にコンパイルする**（peregrine をスキップ）

--- a/spike/abi/lake-manifest.json
+++ b/spike/abi/lake-manifest.json
@@ -1,0 +1,12 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages":
+ [{"type": "path",
+   "scope": "",
+   "name": "lean_to_lambdabox",
+   "manifestFile": "lake-manifest.json",
+   "inherited": false,
+   "dir": "../../tools/lean-to-lambdabox",
+   "configFile": "lakefile.toml"}],
+ "name": "spike_abi",
+ "lakeDir": ".lake"}

--- a/spike/abi/lakefile.toml
+++ b/spike/abi/lakefile.toml
@@ -1,0 +1,11 @@
+name = "spike_abi"
+version = "0.1.0"
+defaultTargets = ["Tests"]
+
+[[require]]
+name = "lean_to_lambdabox"
+path = "../../tools/lean-to-lambdabox"
+
+[[lean_lib]]
+name = "Tests"
+roots = ["src.AbiSpike"]

--- a/spike/abi/lean-toolchain
+++ b/spike/abi/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.22.0

--- a/spike/abi/src/AbiSpike.lean
+++ b/spike/abi/src/AbiSpike.lean
@@ -1,0 +1,53 @@
+import LeanToLambdaBox
+
+/-
+  ABI spike: test ByteArray and custom byte types through #erase.
+
+  ByteArray is a Lean built-in opaque type, so #erase is expected to fail.
+  The fallback uses custom inductive types to simulate byte serialization.
+-/
+
+-- Attempt 1: ByteArray (expected to fail)
+-- Uncomment to test:
+-- set_option compiler.extract_closed false in
+-- def trivialBA (input : @& ByteArray) : ByteArray := input
+-- open Erasure in
+-- #erase trivialBA to "extraction/trivialBA.ast"
+
+-- Fallback: custom byte types for serialization testing
+set_option compiler.extract_closed false in
+inductive Bit where
+  | b0 : Bit
+  | b1 : Bit
+
+set_option compiler.extract_closed false in
+inductive Byte where
+  | mk : Bit -> Bit -> Bit -> Bit -> Bit -> Bit -> Bit -> Bit -> Byte
+
+set_option compiler.extract_closed false in
+inductive ByteList where
+  | nil : ByteList
+  | cons : Byte -> ByteList -> ByteList
+
+set_option compiler.extract_closed false in
+def byteIdentity (bs : ByteList) : ByteList := bs
+
+set_option compiler.extract_closed false in
+def byteLength : ByteList -> Nat
+  | .nil => 0
+  | .cons _ rest => 1 + byteLength rest
+
+set_option compiler.extract_closed false in
+def byteConcat (a b : ByteList) : ByteList :=
+  match a with
+  | .nil => b
+  | .cons x rest => .cons x (byteConcat rest b)
+
+open Erasure in
+#erase byteIdentity config { nat := .peano, extern := .preferLogical } to "extraction/byteIdentity.ast"
+
+open Erasure in
+#erase byteLength config { nat := .peano, extern := .preferLogical } to "extraction/byteLength.ast"
+
+open Erasure in
+#erase byteConcat config { nat := .peano, extern := .preferLogical } to "extraction/byteConcat.ast"

--- a/spike/trivial/lake-manifest.json
+++ b/spike/trivial/lake-manifest.json
@@ -1,0 +1,12 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages":
+ [{"type": "path",
+   "scope": "",
+   "name": "lean_to_lambdabox",
+   "manifestFile": "lake-manifest.json",
+   "inherited": false,
+   "dir": "../../tools/lean-to-lambdabox",
+   "configFile": "lakefile.toml"}],
+ "name": "spike_trivial",
+ "lakeDir": ".lake"}

--- a/spike/trivial/lakefile.toml
+++ b/spike/trivial/lakefile.toml
@@ -1,0 +1,11 @@
+name = "spike_trivial"
+version = "0.1.0"
+defaultTargets = ["Tests"]
+
+[[require]]
+name = "lean_to_lambdabox"
+path = "../../tools/lean-to-lambdabox"
+
+[[lean_lib]]
+name = "Tests"
+roots = ["src.Trivial"]

--- a/spike/trivial/lean-toolchain
+++ b/spike/trivial/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.22.0

--- a/spike/trivial/src/Trivial.lean
+++ b/spike/trivial/src/Trivial.lean
@@ -1,0 +1,21 @@
+import LeanToLambdaBox
+
+set_option compiler.extract_closed false in
+inductive Nat_ where
+  | zero : Nat_
+  | suc : Nat_ -> Nat_
+
+set_option compiler.extract_closed false in
+def identity (n : Nat_) : Nat_ := n
+
+set_option compiler.extract_closed false in
+def add (a b : Nat_) : Nat_ :=
+  match a with
+  | .zero => b
+  | .suc n => .suc (add n b)
+
+open Erasure in
+#erase identity config { nat := .peano, extern := .preferLogical } to "extraction/identity.ast"
+
+open Erasure in
+#erase add config { nat := .peano, extern := .preferLogical } to "extraction/add.ast"


### PR DESCRIPTION
## Summary

- Set up peregrine-tool and lean-to-lambdabox as local-only untracked tools with gitignore entries and justfile recipes
- Created `spike/trivial/` testing Lean → LambdaBox → Rust extraction pipeline
- Created `spike/abi/` testing ByteArray and custom byte type serialization
- Documented toolchain versions (SHAs, opam packages) and findings

## Key Finding

**`.ast → Rust` gate FAILED**: peregrine's Rust backend requires **typed** lambda box input (`.tast`), but lean-to-lambdabox only produces **untyped** output (`.ast`). The C and OCaml backends accept untyped input and work correctly.

**Go/No-Go for Issue #5: NO-GO via Rust backend.** Alternative paths (C backend, upstream enhancement) documented in `spike/FINDINGS.md`.

## Test plan

- [x] `cd spike/trivial && lake build` → `.ast` files generated
- [x] `peregrine rust identity.ast` → fails with "Rust extraction requires typed lambda box input"
- [x] `peregrine c identity.ast` → generates valid C code
- [x] `cd spike/abi && lake build` → custom byte type `.ast` files generated
- [x] `cargo check` → repo builds without `tools/` directory
- [x] All peregrine/lean-to-lambdabox tools remain in `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)