### PR TITLE
feat: optimize trace size — 8.14 GB → 683 MB (11.9x reduction)

### DIFF
--- a/docs/lean-ir-interpreter-diff.md
+++ b/docs/lean-ir-interpreter-diff.md
@@ -1,0 +1,308 @@
+# Lean `ir_interpreter.cpp` と現在の Rust 実装の差分
+
+対象:
+
+- Lean 本体: `lean4/src/library/ir_interpreter.cpp`
+  - https://github.com/leanprover/lean4/blob/master/src/library/ir_interpreter.cpp
+- 現在の Rust 実装: `verifiable-stf` 配下の IR trace interpreter
+
+## 結論
+
+現在の Rust 実装は、Lean 本体の IR interpreter をそのまま移植したものではない。
+正確には、
+
+- Lean の λRC IR を実行するという発想は引き継いでいる
+- ただし実装目的は別で、zk/trace 用にかなり再構成されている
+- 特に「忠実な再現」より「トレース生成と後段検証しやすさ」を優先している
+
+そのため、Lean 本体との差分はかなり大きい。
+
+## 1. 目的の差分
+
+### Lean 本体
+
+Lean 本体の `ir_interpreter.cpp` は、Lean の IR を実際に実行するための interpreter。
+コメントでも「単純さを優先した IR interpreter」であることが明示されている。
+
+### Rust 実装
+
+Rust 実装の主目的は、IR を実行することに加えて、
+
+- 中間値を保存する
+- 操作手順を記録する
+- 後段の verifier で検証できる形にする
+
+ことにある。
+
+### 影響
+
+この時点で役割が違うので、Rust 実装は Lean 本体の「実行器」そのものではない。
+「IR を動かす」という一点は共通だが、最適化対象も設計判断も異なる。
+
+## 2. 値表現の差分
+
+### Lean 本体
+
+Lean ランタイムの本物の値表現を使う。
+boxed/unboxed、オブジェクト、クロージャなどは Lean 実行系の表現そのもの。
+
+### Rust 実装
+
+Rust 独自の `Value` enum を使う。
+
+- `Scalar`
+- `Object`
+- `Array`
+- `ByteArray`
+- `Closure`
+- `Nat`
+- `Str`
+- `Irrelevant`
+
+### 忠実に再現できていない点
+
+- Lean ランタイムの実メモリ表現ではない
+- boxed/unboxed の本来の扱いをそのまま再現していない
+- Lean のランタイム上の不変条件をそのまま持っていない
+- closure や object の内部表現は Rust 側の近似モデル
+
+### 影響
+
+Rust 実装は「Lean の本物の値を動かしている」のではなく、
+「Lean の値っぽいものを Rust で再構成している」に近い。
+
+## 3. 実行モデルの差分
+
+### Lean 本体
+
+Lean 本体は homogeneous stack を中心とした低レベルな実装で、
+
+- 値スタック
+- base pointer
+- variable index
+- call stack metadata
+- join point 用スタック
+
+のような仕組みで回る。
+
+### Rust 実装
+
+Rust 実装はより高水準で、
+
+- `CallFrame`
+- `get_var` / `set_var`
+- `BodyExecutor`
+- `ExprEvaluator`
+
+などの構造体ベースで実装している。
+
+### 忠実に再現できていない点
+
+- 本家のスタック機械をそのまま移していない
+- base pointer + slot index 方式ではない
+- ランタイム寄りの評価器というより、AST/IR を素直に辿る評価器になっている
+
+### 影響
+
+意味上は近くても、内部の挙動・コスト構造・実装上の前提はかなり異なる。
+「Lean 本体と同じ実行機構」とは言えない。
+
+## 4. extern / native function 呼び出しの差分
+
+### Lean 本体
+
+Lean 本体は、可能ならネイティブコード側に切り替える。
+コメントでも、シンボル探索を通じて外部関数や native code を呼ぶ説明がある。
+
+### Rust 実装
+
+Rust 実装では、
+
+- primitive は Rust 側で直接実装
+- extern は `extern_stubs` に登録したスタブで処理
+- 未対応 extern は警告を出して簡略処理する場合がある
+
+### 忠実に再現できていない点
+
+- Lean 本体の native 連携方式を再現していない
+- ABI やシンボル解決の仕組みを持っていない
+- 「Lean ですでにコンパイル済みのコードを呼ぶ」方向ではない
+
+### 影響
+
+Rust 実装は本家の実行環境との接続が弱い。
+必要な extern を人力で stub 化しているため、一般性は低い。
+
+## 5. トレース機構の追加
+
+### Lean 本体
+
+通常の interpreter なので、主眼は「実行結果を得ること」。
+
+### Rust 実装
+
+Rust 実装は追加で以下を持つ。
+
+- `value_table`
+- `TraceStep`
+- `output_value_id`
+- `TraceHeader`
+- 出力 hash や step/value count
+
+### 忠実に再現できていない点
+
+これは「再現できていない」というより、目的が別なので大きく拡張されている。
+本家には存在しない責務である。
+
+### 影響
+
+Rust 実装は interpreter であると同時に、監査ログ生成器でもある。
+そのため設計全体が「検証用に記録しやすいか」に引っ張られている。
+
+## 6. 値保存戦略の差分
+
+### Lean 本体
+
+Lean 本体は runtime の値を使ってその場で実行する。
+少なくとも Rust 実装のような「中間値を全件 value table に保存する」発想ではない。
+
+### Rust 実装
+
+現在の Rust 実装は、中間値を `value_table` に都度 clone して積んでいく。
+
+### 忠実に再現できていない点
+
+- 本家のランタイム実行とはまったく別の保存戦略
+- 同じ値でも何度も複製して保存する
+- トレース都合の人工的なデータ構造が中心になっている
+
+### 影響
+
+巨大な `ByteArray` や `Object` が何度も保存され、サイズが急増する。
+これは Lean 本体の interpreter 由来の問題ではなく、Rust 実装独自の問題。
+
+## 7. 検証可能性のための単純化
+
+### Lean 本体
+
+Lean 本体は「Lean として正しく動くこと」が基準。
+
+### Rust 実装
+
+Rust 実装は「あとから verifier が追えること」も基準なので、
+
+- 値に `ValueId` を振る
+- 操作を `TraceStep` にする
+- 計算過程を後追いできる形にする
+
+という単純化を入れている。
+
+### 忠実に再現できていない点
+
+- 本家の自然な実行状態をそのまま露出していない
+- verifier に都合の良い表現へ落とし込んでいる
+- 実行モデルより「説明可能な記録モデル」が前面に出ている
+
+### 影響
+
+Rust 実装は本家より「検証のために見やすい」一方で、
+Lean 本体そのものの挙動をそのまま写したものではない。
+
+## 8. 意味保存の不完全さ
+
+### Lean 本体
+
+当然ながら、実行に必要な更新は全部その場で処理する。
+
+### Rust 実装
+
+Rust 実装では、実行される更新の一部が trace/verifier に十分に現れていない。
+
+例:
+
+- `USet`
+- `SSet`
+- `SetTag`
+
+これらは実行されるが、現在の trace/verifier では十分に検証可能な形になっていない。
+
+### 忠実に再現できていない点
+
+- 実行はしても、その意味を完全にはトレース化できていない
+- verifier が追える意味と、interpreter が実際にやっている意味にズレがある
+
+### 影響
+
+これは「Lean 本体に対する忠実性」というより、
+「Rust 実装の実行意味と検証意味が一致していない」という問題。
+特に zk/証明用途では重要。
+
+## 9. 完全性よりワークロード適応を優先している
+
+### Lean 本体
+
+汎用の Lean IR interpreter。
+
+### Rust 実装
+
+特定のワークロードを動かすために、
+
+- ETH2 向け stub
+- primitive の個別実装
+- 一部 path の簡略化
+- `_boxed` 系の特別扱い
+
+などを入れている。
+
+### 忠実に再現できていない点
+
+- Lean 全般をカバーする完全実装ではない
+- 必要なケースに合わせた実用寄りの近似
+- 本家の汎用 interpreter とは守備範囲が違う
+
+### 影響
+
+「手元の対象 IR を動かす」には十分でも、
+Lean 本体の interpreter の代替とは言えない。
+
+## 差分の重要度
+
+### 高
+
+- Lean ランタイムの本物の値表現を使っていない
+- native/extern 呼び出し方式を再現していない
+- trace/verifier 都合で設計が大きく変わっている
+- 一部更新操作が完全には検証可能になっていない
+
+### 中
+
+- スタック機械の実装スタイルが異なる
+- 汎用 interpreter ではなく対象ワークロード寄り
+
+### 低
+
+- データ構造や API の細部差分
+- 実装言語の違いによる表現差
+
+## まとめ
+
+現在の Rust 実装は、Lean 本体の `ir_interpreter.cpp` の
+
+- 入力が λRC IR である
+- IR を辿って評価する
+- 関数・primitive・extern を区別する
+
+という骨格はかなり参考にしている。
+
+一方で、以下は忠実再現ではない。
+
+- Lean ランタイムの値表現
+- スタック機械としての内部構造
+- native/extern 連携
+- 汎用 interpreter としての完全性
+- 実行意味と検証意味の一致
+
+したがって、この Rust 実装は
+「Lean 本体の Rust 移植」ではなく、
+「Lean IR interpreter の考え方を借りた、trace/verifier 向けの再設計版」
+と説明するのが最も正確。

--- a/docs/trace-optimization-report.md
+++ b/docs/trace-optimization-report.md
@@ -1,0 +1,103 @@
+---
+title: Trace Optimization Report
+last_updated: 2026-03-24
+tags:
+  - optimization
+  - benchmark
+  - ir-trace
+---
+
+# Trace Optimization Report
+
+## Summary
+
+Three optimizations reduced the ETH2 N=10 trace from **8.14 GB to 683 MB** (11.9x reduction), bringing it well within the zkVM's ~4 GB input limit.
+
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| **Trace size (bincode)** | 8.14 GB | 683 MB | **-91.6%** (11.9x) |
+| **Value table entries** | 639,836 | 40,649 | **-93.6%** (15.7x) |
+| **Trace steps** | 238,049 | 186,921 | **-21.5%** |
+| Median interpreter time | 7.71s | 8.37s | +8.6% |
+
+## Optimizations Applied
+
+### 1. Call Step Removal
+
+`TraceStep::Call` was removed from the trace. The guest verifier never verified Call steps — they served only as function boundary markers, while correctness was already guaranteed by the sub-steps (PrimResult, Branch, etc.) within each function body.
+
+- **Steps removed**: 51,128 (21.5% of total)
+- **Value registrations avoided**: ~200K (args + result per Call)
+
+### 2. Fingerprint-Based Value Deduplication
+
+Replaced the append-only `Vec<Value>` with a `ValueRegistry` that uses fingerprint-based deduplication (`HashMap<u64, Vec<ValueId>>`). When a value is registered, its hash is computed and compared against existing entries. If an exact match exists, the existing `ValueId` is returned without cloning.
+
+- **Value table reduction**: 639,836 → 40,649 entries (15.7x)
+- This was the dominant optimization — most intermediate values were duplicates created by repeated field projections and primitive operations on the same data.
+
+### 3. Dead Value Pruning
+
+After trace generation, a compaction pass removes values not referenced by any trace step or the output. All `ValueId` references are remapped to a contiguous range.
+
+- Removes values that were registered but never used in a verification step.
+- Ownership is moved from the interpreter via `std::mem::take()` to avoid peak memory doubling.
+
+## Defensive Verification Checks Added
+
+The guest verifier now validates:
+- `header.magic == TRACE_MAGIC`
+- `header.value_count == value_table.len()`
+- `header.step_count == steps.len()`
+- `output_value_id < value_table.len()`
+- All `ValueId` references in every step are within bounds
+- `CtorCreate` scalar content (previously only length was checked)
+
+## Semantic Preservation
+
+All three optimizations preserve the proof's semantics:
+- **Call removal**: Call steps performed no verification; sub-steps still verify all computation.
+- **Deduplication**: Same values, same verification — just fewer copies in the table.
+- **Pruning**: Unreferenced values were never checked by the verifier.
+
+The Lean 4 STF correctness proof (IR program hash + input hash → verified computation → output hash) is fully preserved.
+
+## Performance Notes
+
+- Interpreter time increased ~8.6% (7.71s → 8.37s) due to fingerprint computation on the hot path.
+- This overhead is acceptable given the 11.9x trace size reduction.
+- If needed, switching to `ahash` could reduce the hashing overhead.
+
+## Benchmark Environment
+
+```
+Entry: risc0_main_eth2
+Input: 79,510 bytes (10 validators)
+Runs: 3 (median reported)
+Profile: release
+```
+
+### After Optimization (N=10, 3 runs)
+
+```
+Timing:     8.37s (median), 7.97s (min), 11.09s (max)
+
+Trace Steps:  186,921
+  Branch:        27,111 (14.5%)
+  PrimResult:   100,490 (53.8%)
+  CtorCreate:    10,865 (5.8%)
+  ProjResult:    39,701 (21.2%)
+  SetResult:      8,754 (4.7%)
+
+Value table:  40,649 entries
+Trace size:   683 MB (bincode)
+Output:       78,522 bytes (Success)
+```
+
+## zkVM Status
+
+| Format | Before | After | Status |
+|--------|--------|-------|--------|
+| bincode | 8.14 GB | **683 MB** | Within ~4 GB limit |
+
+The ETH2 N=10 trace can now be passed to the zkVM guest for verification.

--- a/ir-trace-common/src/trace_types.rs
+++ b/ir-trace-common/src/trace_types.rs
@@ -129,11 +129,6 @@ pub enum PrimOp {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TraceStep {
-    Call {
-        fn_id: u32,
-        args: Vec<ValueId>,
-        result: ValueId,
-    },
     Branch {
         scrutinee: ValueId,
         chosen_tag: u16,
@@ -167,6 +162,5 @@ pub struct Trace {
     pub header: TraceHeader,
     pub value_table: Vec<Value>,
     pub steps: Vec<TraceStep>,
-    pub fn_name_table: Vec<String>,
     pub output_value_id: ValueId,
 }

--- a/ir-trace-common/src/trace_types.rs
+++ b/ir-trace-common/src/trace_types.rs
@@ -4,7 +4,7 @@ use crate::value::Value;
 
 pub type ValueId = u32;
 
-pub const TRACE_MAGIC: [u8; 4] = *b"LT01";
+pub const TRACE_MAGIC: [u8; 4] = *b"LT02";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceHeader {

--- a/ir-trace-common/src/value.rs
+++ b/ir-trace-common/src/value.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Value {
     Scalar(u64),
     Object {

--- a/methods/guest-ir-trace/src/verifier.rs
+++ b/methods/guest-ir-trace/src/verifier.rs
@@ -1,13 +1,44 @@
 use ir_trace_common::primitives::eval_primitive;
-use ir_trace_common::trace_types::{Trace, TraceStep};
+use ir_trace_common::trace_types::{Trace, TraceStep, TRACE_MAGIC};
 use ir_trace_common::value::Value;
 
 pub fn verify_trace(trace: &Trace) {
+    // Defensive header checks
+    assert_eq!(
+        trace.header.magic, TRACE_MAGIC,
+        "Invalid trace magic"
+    );
+    assert_eq!(
+        trace.header.value_count as usize,
+        trace.value_table.len(),
+        "Header value_count ({}) != value_table.len() ({})",
+        trace.header.value_count,
+        trace.value_table.len()
+    );
+    assert_eq!(
+        trace.header.step_count as usize,
+        trace.steps.len(),
+        "Header step_count ({}) != steps.len() ({})",
+        trace.header.step_count,
+        trace.steps.len()
+    );
+    let vlen = trace.value_table.len() as u32;
+    assert!(
+        trace.output_value_id < vlen,
+        "output_value_id ({}) out of range (value_table has {} entries)",
+        trace.output_value_id,
+        vlen
+    );
+
     let values = &trace.value_table;
 
     for (i, step) in trace.steps.iter().enumerate() {
         match step {
             TraceStep::PrimResult { op, args, result } => {
+                assert!(*result < vlen, "PrimResult result id out of range at step {}", i);
+                for a in args {
+                    assert!(*a < vlen, "PrimResult arg id out of range at step {}", i);
+                }
                 let arg_values: Vec<Value> = args
                     .iter()
                     .map(|id| values[*id as usize].clone())
@@ -25,6 +56,7 @@ pub fn verify_trace(trace: &Trace) {
                 scrutinee,
                 chosen_tag,
             } => {
+                assert!(*scrutinee < vlen, "Branch scrutinee id out of range at step {}", i);
                 let val = &values[*scrutinee as usize];
                 assert_eq!(
                     val.tag(),
@@ -41,6 +73,10 @@ pub fn verify_trace(trace: &Trace) {
                 scalar_data,
                 result,
             } => {
+                assert!(*result < vlen, "CtorCreate result id out of range at step {}", i);
+                for f in fields {
+                    assert!(*f < vlen, "CtorCreate field id out of range at step {}", i);
+                }
                 let obj = &values[*result as usize];
                 assert_eq!(
                     obj.tag(),
@@ -70,9 +106,8 @@ pub fn verify_trace(trace: &Trace) {
                             );
                         }
                         assert_eq!(
-                            scalars.len(),
-                            scalar_data.len(),
-                            "Ctor scalar size mismatch at step {}",
+                            scalars, scalar_data,
+                            "Ctor scalar content mismatch at step {}",
                             i
                         );
                     }
@@ -80,6 +115,8 @@ pub fn verify_trace(trace: &Trace) {
                 }
             }
             TraceStep::ProjResult { obj, idx, result } => {
+                assert!(*obj < vlen, "ProjResult obj id out of range at step {}", i);
+                assert!(*result < vlen, "ProjResult result id out of range at step {}", i);
                 let obj_val = &values[*obj as usize];
                 let expected = obj_val.field(*idx as usize);
                 assert_eq!(
@@ -95,6 +132,9 @@ pub fn verify_trace(trace: &Trace) {
                 val,
                 result,
             } => {
+                assert!(*obj < vlen, "SetResult obj id out of range at step {}", i);
+                assert!(*val < vlen, "SetResult val id out of range at step {}", i);
+                assert!(*result < vlen, "SetResult result id out of range at step {}", i);
                 let mut expected = values[*obj as usize].clone();
                 expected.set_field(*idx as usize, values[*val as usize].clone());
                 assert_eq!(
@@ -103,10 +143,6 @@ pub fn verify_trace(trace: &Trace) {
                     "Set verification failed at step {}",
                     i
                 );
-            }
-            TraceStep::Call { .. } => {
-                // User function calls: verified via their sub-steps
-                // Extern calls (crypto stubs): trusted as axioms
             }
         }
     }

--- a/tools/ir-trace/src/interpreter.rs
+++ b/tools/ir-trace/src/interpreter.rs
@@ -5,6 +5,7 @@ pub mod stack;
 pub mod value;
 
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 
 use ir_trace_common::trace_types::{TraceStep, ValueId};
 
@@ -17,12 +18,45 @@ use value::Value;
 
 const MAX_CALL_DEPTH: usize = 10000;
 
+pub struct ValueRegistry {
+    pub table: Vec<Value>,
+    fingerprints: HashMap<u64, Vec<ValueId>>,
+}
+
+impl ValueRegistry {
+    pub fn new() -> Self {
+        Self {
+            table: Vec::new(),
+            fingerprints: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, val: &Value) -> ValueId {
+        let fp = Self::fingerprint(val);
+        if let Some(candidates) = self.fingerprints.get(&fp) {
+            for &cid in candidates {
+                if self.table[cid as usize] == *val {
+                    return cid;
+                }
+            }
+        }
+        let id = self.table.len() as ValueId;
+        self.table.push(val.clone());
+        self.fingerprints.entry(fp).or_default().push(id);
+        id
+    }
+
+    fn fingerprint(val: &Value) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        val.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
 pub struct Interpreter {
     pub decls: HashMap<String, Decl>,
     pub trace_steps: Vec<TraceStep>,
-    pub value_table: Vec<Value>,
-    pub fn_name_table: Vec<String>,
-    fn_name_index: HashMap<String, u32>,
+    pub value_registry: ValueRegistry,
     call_depth: usize,
     pub extern_stubs: HashMap<String, Box<dyn Fn(&[Value]) -> Value>>,
 }
@@ -32,9 +66,7 @@ impl Interpreter {
         Interpreter {
             decls,
             trace_steps: Vec::new(),
-            value_table: Vec::new(),
-            fn_name_table: Vec::new(),
-            fn_name_index: HashMap::new(),
+            value_registry: ValueRegistry::new(),
             call_depth: 0,
             extern_stubs: HashMap::new(),
         }
@@ -46,22 +78,6 @@ impl Interpreter {
         f: Box<dyn Fn(&[Value]) -> Value>,
     ) {
         self.extern_stubs.insert(name.to_string(), f);
-    }
-
-    fn get_fn_id(&mut self, name: &str) -> u32 {
-        if let Some(id) = self.fn_name_index.get(name) {
-            return *id;
-        }
-        let id = self.fn_name_table.len() as u32;
-        self.fn_name_table.push(name.to_string());
-        self.fn_name_index.insert(name.to_string(), id);
-        id
-    }
-
-    fn register_value(&mut self, val: &Value) -> ValueId {
-        let id = self.value_table.len() as ValueId;
-        self.value_table.push(val.clone());
-        id
     }
 
     pub fn call_function(&mut self, name: &str, args: Vec<Value>) -> Value {
@@ -81,8 +97,8 @@ impl Interpreter {
         // Check for primitive operations first
         if let Some(prim_op) = lookup_primitive(name) {
             let result = call_primitive(&prim_op, args.clone());
-            let arg_ids: Vec<ValueId> = args.iter().map(|a| self.register_value(a)).collect();
-            let result_id = self.register_value(&result);
+            let arg_ids: Vec<ValueId> = args.iter().map(|a| self.value_registry.register(a)).collect();
+            let result_id = self.value_registry.register(&result);
             self.trace_steps.push(TraceStep::PrimResult {
                 op: prim_op,
                 args: arg_ids,
@@ -91,18 +107,9 @@ impl Interpreter {
             return result;
         }
 
-        // Check for extern stubs
+        // Check for extern stubs (trusted as axioms, not traced)
         if let Some(stub) = self.extern_stubs.get(name) {
-            let result = stub(&args);
-            let fn_id = self.get_fn_id(name);
-            let arg_ids: Vec<ValueId> = args.iter().map(|a| self.register_value(a)).collect();
-            let result_id = self.register_value(&result);
-            self.trace_steps.push(TraceStep::Call {
-                fn_id,
-                args: arg_ids,
-                result: result_id,
-            });
-            return result;
+            return stub(&args);
         }
 
         // Look up declaration
@@ -128,8 +135,8 @@ impl Interpreter {
                     if let Some(prim) = lookup_primitive(base_name) {
                         let result = call_primitive(&prim, args.clone());
                         let arg_ids: Vec<ValueId> =
-                            args.iter().map(|a| self.register_value(a)).collect();
-                        let result_id = self.register_value(&result);
+                            args.iter().map(|a| self.value_registry.register(a)).collect();
+                        let result_id = self.value_registry.register(&result);
                         self.trace_steps.push(TraceStep::PrimResult {
                             op: prim,
                             args: arg_ids,
@@ -156,10 +163,6 @@ impl Interpreter {
                 body,
                 ..
             } => {
-                let fn_id = self.get_fn_id(fn_name);
-                let arg_ids: Vec<ValueId> =
-                    args.iter().map(|a| self.register_value(a)).collect();
-
                 // Create a new call frame
                 let mut frame = CallFrame::new(fn_name.clone());
                 for (param, val) in params.iter().zip(args.iter()) {
@@ -167,15 +170,7 @@ impl Interpreter {
                 }
 
                 // Execute the body with continuation-based loop
-                let result = self.exec_with_continuations(&mut frame, body);
-
-                let result_id = self.register_value(&result);
-                self.trace_steps.push(TraceStep::Call {
-                    fn_id,
-                    args: arg_ids,
-                    result: result_id,
-                });
-                result
+                self.exec_with_continuations(&mut frame, body)
             }
         }
     }
@@ -188,7 +183,7 @@ impl Interpreter {
                 let mut executor = BodyExecutor {
                     frame,
                     trace_steps: &mut self.trace_steps,
-                    value_table: &mut self.value_table,
+                    value_registry: &mut self.value_registry,
                 };
                 executor.exec(&current_body)
             };

--- a/tools/ir-trace/src/interpreter/eval_expr.rs
+++ b/tools/ir-trace/src/interpreter/eval_expr.rs
@@ -3,11 +3,12 @@ use ir_trace_common::trace_types::{TraceStep, ValueId};
 use crate::ir_types::{Arg, Expr, IRType, LitValue};
 use super::stack::CallFrame;
 use super::value::Value;
+use super::ValueRegistry;
 
 pub struct ExprEvaluator<'a> {
     pub frame: &'a mut CallFrame,
     pub trace_steps: &'a mut Vec<TraceStep>,
-    pub value_table: &'a mut Vec<Value>,
+    pub value_registry: &'a mut ValueRegistry,
 }
 
 impl<'a> ExprEvaluator<'a> {
@@ -16,12 +17,6 @@ impl<'a> ExprEvaluator<'a> {
             Arg::Var(v) => self.frame.get_var(*v).clone(),
             Arg::Irrelevant => Value::Irrelevant,
         }
-    }
-
-    pub fn register_value(&mut self, val: &Value) -> ValueId {
-        let id = self.value_table.len() as ValueId;
-        self.value_table.push(val.clone());
-        id
     }
 
     pub fn eval_with_ty(&mut self, expr: &Expr, ty: &IRType) -> Value {
@@ -50,11 +45,11 @@ impl<'a> ExprEvaluator<'a> {
                 };
                 let field_ids: Vec<ValueId> = match &val {
                     Value::Object { fields, .. } => {
-                        fields.iter().map(|f| self.register_value(f)).collect()
+                        fields.iter().map(|f| self.value_registry.register(f)).collect()
                     }
                     _ => vec![],
                 };
-                let result_id = self.register_value(&val);
+                let result_id = self.value_registry.register(&val);
                 self.trace_steps.push(TraceStep::CtorCreate {
                     tag: info.cidx,
                     fields: field_ids,
@@ -69,8 +64,8 @@ impl<'a> ExprEvaluator<'a> {
             Expr::Proj { idx, var } => {
                 let obj = self.frame.get_var(*var).clone();
                 let field = obj.field(*idx as usize).clone();
-                let obj_id = self.register_value(&obj);
-                let result_id = self.register_value(&field);
+                let obj_id = self.value_registry.register(&obj);
+                let result_id = self.value_registry.register(&field);
                 self.trace_steps.push(TraceStep::ProjResult {
                     obj: obj_id,
                     idx: *idx as u16,

--- a/tools/ir-trace/src/interpreter/exec_body.rs
+++ b/tools/ir-trace/src/interpreter/exec_body.rs
@@ -1,15 +1,16 @@
-use ir_trace_common::trace_types::{TraceStep, ValueId};
+use ir_trace_common::trace_types::TraceStep;
 
 use crate::ir_types::{Alt, Arg, FnBody, IRType};
 
 use super::eval_expr::ExprEvaluator;
 use super::stack::CallFrame;
 use super::value::Value;
+use super::ValueRegistry;
 
 pub struct BodyExecutor<'a> {
     pub frame: &'a mut CallFrame,
     pub trace_steps: &'a mut Vec<TraceStep>,
-    pub value_table: &'a mut Vec<Value>,
+    pub value_registry: &'a mut ValueRegistry,
 }
 
 impl<'a> BodyExecutor<'a> {
@@ -20,12 +21,6 @@ impl<'a> BodyExecutor<'a> {
         }
     }
 
-    fn register_value(&mut self, val: &Value) -> ValueId {
-        let id = self.value_table.len() as ValueId;
-        self.value_table.push(val.clone());
-        id
-    }
-
     fn eval_expr_inline_with_ty(
         &mut self,
         expr: &crate::ir_types::Expr,
@@ -34,7 +29,7 @@ impl<'a> BodyExecutor<'a> {
         let mut evaluator = ExprEvaluator {
             frame: self.frame,
             trace_steps: self.trace_steps,
-            value_table: self.value_table,
+            value_registry: self.value_registry,
         };
         evaluator.eval_with_ty(expr, ty)
     }
@@ -110,10 +105,10 @@ impl<'a> BodyExecutor<'a> {
             } => {
                 let mut obj = self.frame.get_var(*var).clone();
                 let new_val = self.resolve_arg(val);
-                let obj_id = self.register_value(&obj);
-                let val_id = self.register_value(&new_val);
+                let obj_id = self.value_registry.register(&obj);
+                let val_id = self.value_registry.register(&new_val);
                 obj.set_field(*idx as usize, new_val);
-                let result_id = self.register_value(&obj);
+                let result_id = self.value_registry.register(&obj);
                 self.trace_steps.push(TraceStep::SetResult {
                     obj: obj_id,
                     idx: *idx as u16,
@@ -170,7 +165,7 @@ impl<'a> BodyExecutor<'a> {
             } => {
                 let val = self.frame.get_var(*scrutinee).clone();
                 let tag = val.tag();
-                let scrutinee_id = self.register_value(&val);
+                let scrutinee_id = self.value_registry.register(&val);
                 self.trace_steps.push(TraceStep::Branch {
                     scrutinee: scrutinee_id,
                     chosen_tag: tag,

--- a/tools/ir-trace/src/main.rs
+++ b/tools/ir-trace/src/main.rs
@@ -104,7 +104,7 @@ fn run_bench(
         durations.push(elapsed);
         eprintln!("  Run {}/{}: {:.3}s", run_idx + 1, args.runs, elapsed.as_secs_f64());
 
-        last_value_count = interp.value_table.len();
+        last_value_count = interp.value_registry.table.len();
         if run_idx == 0 {
             last_steps = std::mem::take(&mut interp.trace_steps);
         }
@@ -117,7 +117,6 @@ fn run_bench(
     let max = durations[durations.len() - 1];
 
     // Count step categories
-    let mut call_count = 0u64;
     let mut branch_count = 0u64;
     let mut prim_count = 0u64;
     let mut ctor_count = 0u64;
@@ -125,7 +124,6 @@ fn run_bench(
     let mut set_count = 0u64;
     for step in &last_steps {
         match step {
-            TraceStep::Call { .. } => call_count += 1,
             TraceStep::Branch { .. } => branch_count += 1,
             TraceStep::PrimResult { .. } => prim_count += 1,
             TraceStep::CtorCreate { .. } => ctor_count += 1,
@@ -148,7 +146,6 @@ fn run_bench(
     eprintln!();
     eprintln!("=== Trace Steps ===");
     eprintln!("  Total:      {:>10}", format_count(total_steps));
-    eprintln!("  Call:        {:>10} ({:.1}%)", format_count(call_count), pct(call_count, total_steps));
     eprintln!("  Branch:      {:>10} ({:.1}%)", format_count(branch_count), pct(branch_count, total_steps));
     eprintln!("  PrimResult:  {:>10} ({:.1}%)", format_count(prim_count), pct(prim_count, total_steps));
     eprintln!("  CtorCreate:  {:>10} ({:.1}%)", format_count(ctor_count), pct(ctor_count, total_steps));
@@ -179,11 +176,10 @@ fn run_trace(
     let result = interp.call_function(&args.entry, vec![input_value]);
 
     // Build trace
-    let output_value_id = interp.value_table.len() as u32;
-    interp.value_table.push(result.clone());
+    let output_value_id = interp.value_registry.register(&result);
 
     let trace = build_trace(
-        &interp,
+        &mut interp,
         ir_program_bytes,
         input_bytes,
         &result,

--- a/tools/ir-trace/src/trace_format.rs
+++ b/tools/ir-trace/src/trace_format.rs
@@ -134,3 +134,87 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
     hash.copy_from_slice(&result);
     hash
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use ir_trace_common::trace_types::TRACE_MAGIC;
+
+    use super::*;
+
+    #[test]
+    fn compact_trace_prunes_unreferenced_values_and_remaps_ids() {
+        let mut trace = Trace {
+            header: TraceHeader {
+                magic: TRACE_MAGIC,
+                ir_program_hash: [0; 32],
+                input_hash: [0; 32],
+                output_hash: [0; 32],
+                value_count: 4,
+                step_count: 1,
+            },
+            value_table: vec![
+                Value::Scalar(10),
+                Value::Scalar(999),
+                Value::Scalar(20),
+                Value::Scalar(30),
+            ],
+            steps: vec![TraceStep::PrimResult {
+                op: ir_trace_common::trace_types::PrimOp::UInt64Add,
+                args: vec![0, 2],
+                result: 3,
+            }],
+            output_value_id: 3,
+        };
+
+        compact_trace(&mut trace);
+
+        assert_eq!(
+            trace.value_table,
+            vec![Value::Scalar(10), Value::Scalar(20), Value::Scalar(30)]
+        );
+        assert_eq!(trace.header.value_count, 3);
+        assert_eq!(trace.header.step_count, 1);
+        assert_eq!(trace.output_value_id, 2);
+
+        match &trace.steps[0] {
+            TraceStep::PrimResult { args, result, .. } => {
+                assert_eq!(args, &vec![0, 1]);
+                assert_eq!(*result, 2);
+            }
+            step => panic!("unexpected step after compaction: {:?}", step),
+        }
+    }
+
+    #[test]
+    fn build_trace_emits_new_magic_and_compacted_counts() {
+        let mut interpreter = Interpreter::new(HashMap::new());
+        interpreter.value_registry.table = vec![
+            Value::Scalar(1),
+            Value::Scalar(777),
+            Value::Scalar(2),
+        ];
+        interpreter.trace_steps = vec![TraceStep::PrimResult {
+            op: ir_trace_common::trace_types::PrimOp::UInt64Add,
+            args: vec![0],
+            result: 2,
+        }];
+
+        let trace = build_trace(
+            &mut interpreter,
+            b"dummy-ir",
+            b"dummy-input",
+            &Value::Scalar(2),
+            2,
+        );
+
+        assert_eq!(trace.header.magic, TRACE_MAGIC);
+        assert_eq!(trace.header.value_count, 2);
+        assert_eq!(trace.header.step_count, 1);
+        assert_eq!(trace.value_table, vec![Value::Scalar(1), Value::Scalar(2)]);
+        assert_eq!(trace.output_value_id, 1);
+        assert!(interpreter.value_registry.table.is_empty());
+        assert!(interpreter.trace_steps.is_empty());
+    }
+}

--- a/tools/ir-trace/src/trace_format.rs
+++ b/tools/ir-trace/src/trace_format.rs
@@ -1,12 +1,14 @@
+use std::collections::{HashMap, HashSet};
+
 use sha2::{Digest, Sha256};
 
-use ir_trace_common::trace_types::{Trace, TraceHeader, TRACE_MAGIC};
+use ir_trace_common::trace_types::{Trace, TraceHeader, TraceStep, ValueId, TRACE_MAGIC};
 use ir_trace_common::value::Value;
 
 use crate::interpreter::Interpreter;
 
 pub fn build_trace(
-    interpreter: &Interpreter,
+    interpreter: &mut Interpreter,
     ir_program_bytes: &[u8],
     input_bytes: &[u8],
     output_value: &Value,
@@ -17,22 +19,111 @@ pub fn build_trace(
     let output_bytes = output_value.serialize_to_bytes();
     let output_hash = sha256(&output_bytes);
 
+    // Move ownership from interpreter to avoid double-buffering
+    let value_table = std::mem::take(&mut interpreter.value_registry.table);
+    let steps = std::mem::take(&mut interpreter.trace_steps);
+
     let header = TraceHeader {
         magic: TRACE_MAGIC,
         ir_program_hash,
         input_hash,
         output_hash,
-        value_count: interpreter.value_table.len() as u32,
-        step_count: interpreter.trace_steps.len() as u64,
+        value_count: value_table.len() as u32,
+        step_count: steps.len() as u64,
     };
 
-    Trace {
+    let mut trace = Trace {
         header,
-        value_table: interpreter.value_table.clone(),
-        steps: interpreter.trace_steps.clone(),
-        fn_name_table: interpreter.fn_name_table.clone(),
+        value_table,
+        steps,
         output_value_id,
+    };
+
+    compact_trace(&mut trace);
+    trace
+}
+
+/// Remove unreferenced values and compact ValueIds.
+fn compact_trace(trace: &mut Trace) {
+    // Collect all referenced ValueIds
+    let mut referenced = HashSet::new();
+    referenced.insert(trace.output_value_id);
+
+    for step in &trace.steps {
+        match step {
+            TraceStep::PrimResult { args, result, .. } => {
+                referenced.extend(args);
+                referenced.insert(*result);
+            }
+            TraceStep::Branch { scrutinee, .. } => {
+                referenced.insert(*scrutinee);
+            }
+            TraceStep::CtorCreate { fields, result, .. } => {
+                referenced.extend(fields);
+                referenced.insert(*result);
+            }
+            TraceStep::ProjResult { obj, result, .. } => {
+                referenced.insert(*obj);
+                referenced.insert(*result);
+            }
+            TraceStep::SetResult { obj, val, result, .. } => {
+                referenced.insert(*obj);
+                referenced.insert(*val);
+                referenced.insert(*result);
+            }
+        }
     }
+
+    // Build compaction map: old_id -> new_id
+    let mut old_to_new: HashMap<ValueId, ValueId> = HashMap::new();
+    let mut new_table = Vec::new();
+    let old_table = std::mem::take(&mut trace.value_table);
+    for (old_id, value) in old_table.into_iter().enumerate() {
+        let old_id = old_id as ValueId;
+        if referenced.contains(&old_id) {
+            old_to_new.insert(old_id, new_table.len() as ValueId);
+            new_table.push(value);
+        }
+    }
+
+    // Rewrite all ValueId references
+    let remap = |id: &mut ValueId| {
+        *id = old_to_new[id];
+    };
+
+    for step in &mut trace.steps {
+        match step {
+            TraceStep::PrimResult { args, result, .. } => {
+                for a in args.iter_mut() {
+                    remap(a);
+                }
+                remap(result);
+            }
+            TraceStep::Branch { scrutinee, .. } => {
+                remap(scrutinee);
+            }
+            TraceStep::CtorCreate { fields, result, .. } => {
+                for f in fields.iter_mut() {
+                    remap(f);
+                }
+                remap(result);
+            }
+            TraceStep::ProjResult { obj, result, .. } => {
+                remap(obj);
+                remap(result);
+            }
+            TraceStep::SetResult { obj, val, result, .. } => {
+                remap(obj);
+                remap(val);
+                remap(result);
+            }
+        }
+    }
+
+    trace.output_value_id = old_to_new[&trace.output_value_id];
+    trace.value_table = new_table;
+    trace.header.value_count = trace.value_table.len() as u32;
+    trace.header.step_count = trace.steps.len() as u64;
 }
 
 pub fn sha256(data: &[u8]) -> [u8; 32] {


### PR DESCRIPTION
## Summary

Reduces ETH2 N=10 trace from **8.14 GB to 683 MB** (11.9x), bringing it within the zkVM's ~4 GB input limit.

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Trace size (bincode)** | 8.14 GB | 683 MB | **-91.6%** (11.9x) |
| **Value table entries** | 639,836 | 40,649 | **-93.6%** (15.7x) |
| **Trace steps** | 238,049 | 186,921 | **-21.5%** |
| Median interpreter time | 7.71s | 8.37s | +8.6% |

## Changes

### 1. Call Step Removal
- Removed `TraceStep::Call` — the guest verifier never verified it (empty match arm)
- Removed `fn_name_table` from `Trace` struct
- Avoids ~200K value registrations for Call args/result

### 2. Fingerprint-Based Value Deduplication
- Introduced `ValueRegistry` with `HashMap<u64, Vec<ValueId>>` for content-hash dedup
- Values are stored once; subsequent registrations of identical values return existing IDs
- Value table: 639,836 → 40,649 entries (15.7x reduction)

### 3. Dead Value Pruning
- `compact_trace()` removes unreferenced values after trace generation
- Uses `std::mem::take()` to move ownership from Interpreter, avoiding peak memory doubling
- Remaps all `ValueId` references and updates header

### 4. Defensive Verification Checks
- `header.magic`, `value_count`, `step_count` integrity
- `output_value_id` bounds check
- Per-step `ValueId` range validation
- `CtorCreate` scalar content verification (was length-only)

## Semantic Preservation

All optimizations preserve the Lean 4 STF proof:
- Call steps were never verified → removal is safe
- Dedup returns same values at consistent indices → verification unchanged
- Pruned values were never referenced → no impact on verification

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all 7 tests pass
- [x] ETH2 N=10 benchmark: trace generates successfully at 683 MB
- [x] Output matches expected (78,522 bytes, Success)
- [ ] `just verify-ir-trace` — E2E zkVM verification (requires riscv32im target)

See `docs/trace-optimization-report.md` for full benchmark details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)